### PR TITLE
Refactor main loop to be more rusty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ cc = "1.0.71"
 [profile.release]
 debug = 1           # Add debug symbols for profiling
 lto = "fat"         # Enable Link Time Optimization
-# codegen-units = 1 # Reduce number of codegen units to increase optimizations.
+codegen-units = 1 # Reduce number of codegen units to increase optimizations.

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@
 // The libsais library is released under Apache License 2.0 and is not modified for the purposes of this project
 // Copyright of the libsais library (c) 2021 Ilya Grebnov <ilya.grebnov@gmail.com>
 
+// Uses libsais v2.70
+
 fn main() {
     cc::Build::new()
         .flag("-Wno-unused-parameter")

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -3,12 +3,26 @@
 extern "C" {
     #[doc = " Constructs the suffix array of a given string."]
     #[doc = " @param T [0..n-1] The input string."]
-    #[doc = " @param SA [0..n-1] The output array of suffixes."]
+    #[doc = " @param SA [0..n-1+fs] The output array of suffixes."]
     #[doc = " @param n The length of the given string."]
+    #[doc = " @param fs The extra space available at the end of SA array (0 should be enough for most cases)."]
+    #[doc = " @param freq [0..255] The output symbol frequency table (can be NULL)."]
     #[doc = " @return 0 if no error occurred, -1 or -2 otherwise."]
-    pub fn libsais(
-        T: *const ::std::os::raw::c_uchar,
-        SA: *mut ::std::os::raw::c_int,
-        n: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn libsais(T: *const u8, SA: *mut i32, n: i32, fs: i32, freq: *mut i32) -> i32;
+
+    #[doc = " Constructs the permuted longest common prefix array (PLCP) of a given string and a suffix array."]
+    #[doc = " @param T [0..n-1] The input string."]
+    #[doc = " @param SA [0..n-1] The input suffix array."]
+    #[doc = " @param PLCP [0..n-1] The output permuted longest common prefix array."]
+    #[doc = " @param n The length of the string and the suffix array."]
+    #[doc = " @return 0 if no error occurred, -1 otherwise."]
+    pub fn libsais_plcp(T: *const u8, SA: *const i32, PLCP: *mut i32, n: i32) -> i32;
+
+    #[doc = " Constructs the longest common prefix array (LCP) of a given permuted longest common prefix array (PLCP) and a suffix array."]
+    #[doc = " @param PLCP [0..n-1] The input permuted longest common prefix array."]
+    #[doc = " @param SA [0..n-1] The input suffix array."]
+    #[doc = " @param LCP [0..n-1] The output longest common prefix array (can be SA)."]
+    #[doc = " @param n The length of the permuted longest common prefix array and the suffix array."]
+    #[doc = " @return 0 if no error occurred, -1 otherwise."]
+    pub fn libsais_lcp(PLCP: *const i32, SA: *const i32, LCP: *mut i32, n: i32) -> i32;
 }

--- a/src/counting.rs
+++ b/src/counting.rs
@@ -1,21 +1,22 @@
+use std::ops::Neg;
 use crate::match_finder::Match;
 use crate::mdma::MdmaIndex;
 
-pub fn count(m: &mut Match, mdma_index: &MdmaIndex) -> (i32, usize) {
-    match m.self_ref {
-        false => count_fast(m, mdma_index),
-        true => count_slow(m, mdma_index)
-    }
+pub fn count(m: &mut Match, mdma_index: &MdmaIndex) -> (u32, usize) {
+    if m.self_ref { count_slow(m, mdma_index) }
+    else          { count_fast(m, mdma_index) }
 }
 
-fn count_fast(m: &mut Match, mdma_index: &MdmaIndex) -> (i32, usize) {
+// Casts here are safe just unproven because libsais uses i32-s for the SA
+fn count_fast(m: &mut Match, mdma_index: &MdmaIndex) -> (u32, usize) {
     let mut count = 0;
-    let effective_len = m.len as i32 - 1;
+    let effective_len = i32::from(m.len) - 1;
 
     let last_match = mdma_index.sa[m.sa_index as usize] as usize;
     let range = m.get_range();
 
     // TODO: Try unroll?
+    // TODO: Prefetch?
     for loc in &mdma_index.sa[range] {
         if mdma_index.offsets[*loc as usize] >= effective_len { count += 1; }
     }
@@ -23,16 +24,17 @@ fn count_fast(m: &mut Match, mdma_index: &MdmaIndex) -> (i32, usize) {
     (count, last_match)
 }
 
-fn count_slow(m: &mut Match, mdma_index: &MdmaIndex) -> (i32, usize) {
+// Casts here are safe just unproven because libsais uses i32-s for the SA
+fn count_slow(m: &mut Match, mdma_index: &MdmaIndex) -> (u32, usize) {
     let range = m.get_range();
     let mut locations = vec![0; range.len()];
     locations.copy_from_slice(&mdma_index.sa[range]);
     locations.sort_unstable();
 
-    let effective_len = m.len as i32 - 1;
+    let effective_len = i32::from(m.len) - 1;
     let mut count = 0;
     let mut flag = false;
-    let mut last_match = - (m.len as i32);
+    let mut last_match = i32::from(m.len).neg(); // 0-len
 
     for loc in locations {
         // TODO: Optimize branching? -> there're no branches in the loop,
@@ -49,5 +51,5 @@ fn count_slow(m: &mut Match, mdma_index: &MdmaIndex) -> (i32, usize) {
     }
 
     m.self_ref = flag;
-    (count, last_match as usize)
+    (count, last_match.try_into().unwrap_or(usize::MAX))
 }

--- a/src/counting.rs
+++ b/src/counting.rs
@@ -17,8 +17,8 @@ fn count_fast(m: &mut Match, mdma_index: &MdmaIndex) -> (u32, usize) {
 
     // TODO: Try unroll?
     // TODO: Prefetch?
-    for loc in &mdma_index.sa[range] {
-        if mdma_index.offsets[*loc as usize] >= effective_len { count += 1; }
+    for &loc in mdma_index.sa[range].iter() {
+        if mdma_index.offsets[loc as usize] >= effective_len { count += 1; }
     }
 
     (count, last_match)

--- a/src/mdma.rs
+++ b/src/mdma.rs
@@ -11,8 +11,8 @@ pub struct MdmaIndex {
     pub offsets:    Vec<i32>,
     pub model:      [f64; 256],
     pub sym_counts: [f64; 256],
-    pub n:          u32,
-    pub dict_len:   i32
+    pub n: u32,
+    pub replacement_token: i32
 }
 
 // The cast here is ok, because it's just an approximation we're making and the value may never become negative
@@ -51,7 +51,7 @@ pub fn initialize(buf: Vec<u8>) -> MdmaIndex {
     let model = build_model(&buf);
     let offsets = build_offsets_array(buf.len());
 
-    MdmaIndex { n: len, buf, sa, offsets, model, sym_counts: [0f64; 256], dict_len: 0 }
+    MdmaIndex { n: len, buf, sa, offsets, model, sym_counts: [0f64; 256], replacement_token: -256 }
 }
 
 fn build_suffix_array(buf: &[u8]) -> Vec<i32> {

--- a/src/mdma.rs
+++ b/src/mdma.rs
@@ -15,14 +15,24 @@ pub struct MdmaIndex {
     pub replacement_token: i32
 }
 
-// The cast here is ok, because it's just an approximation we're making and the value may never become negative
+pub fn initialize(buf: Vec<u8>) -> MdmaIndex {
+    let len: u32 = buf.len().try_into().expect("Buffer must fit into u32 type!");
+    let sa = build_suffix_array(&buf);
+    let model = build_model(&buf);
+    let offsets = build_offsets_array(buf.len());
+
+    MdmaIndex { n: len, buf, sa, offsets, model, sym_counts: [0f64; 256], replacement_token: -256 }
+}
+
 pub fn build_dictionary(mdma_index: &mut MdmaIndex) -> Vec<Word> {
-    let mut dict = Vec::with_capacity(128);
+    // The cast here is ok, because it's just an approximation we're making and the value may never become negative
     let mut curr_matches = Vec::with_capacity((mdma_index.buf.len() as f64 * 2.3) as usize);
+    let mut dict = Vec::with_capacity(128);
 
     // Initialize with all the macthes
-    // match_finder::_static_analyze(mdma_index);
-    match_finder::generate(mdma_index, &mut curr_matches);
+    // match_finder::_static_analyze(lcp_array);
+    let lcp_array = build_lcp_array(&mdma_index.buf, &mdma_index.sa);
+    match_finder::generate(&mut curr_matches, lcp_array);
 
     loop {
         let best_word = curr_matches.iter_mut()
@@ -45,25 +55,41 @@ pub fn build_dictionary(mdma_index: &mut MdmaIndex) -> Vec<Word> {
     dict
 }
 
-pub fn initialize(buf: Vec<u8>) -> MdmaIndex {
-    let len: u32 = buf.len().try_into().expect("Buffer must fit into u32 type!");
-    let sa = build_suffix_array(&buf);
-    let model = build_model(&buf);
-    let offsets = build_offsets_array(buf.len());
-
-    MdmaIndex { n: len, buf, sa, offsets, model, sym_counts: [0f64; 256], replacement_token: -256 }
-}
-
 fn build_suffix_array(buf: &[u8]) -> Vec<i32> {
     let timer = Instant::now();
     let len: i32 = buf.len().try_into().expect("Buffer must fit into i32 type to use libsais!");
     let mut sa = vec![0; buf.len()];
-    let code = unsafe { bindings::libsais(buf.as_ptr(), sa.as_mut_ptr(), len) };
+
+    let code = unsafe { bindings::libsais(buf.as_ptr(), sa.as_mut_ptr(), len, 0, std::ptr::null_mut::<i32>()) };
     assert!(code == 0);
     assert!(sa.len() == buf.len());
     println!("Built SA in {:?}", timer.elapsed());
 
     sa
+}
+
+fn build_lcp_array(buf: &[u8], sa: &[i32]) -> Vec<i32> {
+    let timer = Instant::now();
+    let len: i32 = buf.len().try_into().expect("Buffer must fit into i32 type to use libsais!");
+    let mut plcp = vec![0; buf.len()];
+    let mut lcp = vec![0; buf.len()+1];
+
+    let code = unsafe { bindings::libsais_plcp(buf.as_ptr(), sa.as_ptr(), plcp.as_mut_ptr(), len) };
+    assert!(code == 0);
+    assert!(plcp.len() == buf.len());
+
+    let code = unsafe { bindings::libsais_lcp(plcp.as_ptr(), sa.as_ptr(), lcp.as_mut_ptr(), len) };
+    assert!(code == 0);
+    // This is a bit of hacky magic because the previous implementation of an LCP array (using kasai's alg)
+    // produced an array ending with 0, while the libsais version has the extra 0 in the beginning
+    // This is ultimately based on where you assume the sentinel token to be placed
+    // As it is purely an implementation choice, I found this to be easier to adapt,
+    // rather than rewriting the matchfinder
+    lcp.remove(0);
+    assert!(lcp.len() == buf.len());
+    println!("Built LCP in {:?}", timer.elapsed());
+
+    lcp
 }
 
 fn build_offsets_array(len: usize) -> Vec<i32> {


### PR DESCRIPTION
The major change of this PR is not copying over matches.  
Instead they are flagged when re-ranking them is pointless.  
The flag added doesn't take additional space, and was before used as free a byte for memory alignment.

Additionally, most unsafe casts were replaced with their safe alternatives.
Reading and writing to files is safer now too.